### PR TITLE
Remove reference to Microsoft.Expression.Interactions

### DIFF
--- a/Styling/DragAndDrop/DragOverConditional/DragOverBehavior.cs
+++ b/Styling/DragAndDrop/DragOverConditional/DragOverBehavior.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace DragOverConditional
 {

--- a/Styling/DragAndDrop/DragOverConditional/DragOverConditional.csproj
+++ b/Styling/DragAndDrop/DragOverConditional/DragOverConditional.csproj
@@ -40,11 +40,11 @@
     <Reference Include="MaterialDesignThemes.Wpf, Version=2.5.1.1345, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\MaterialDesignThemes.2.5.1\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.0.1\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Windows.Interactivity">
-      <HintPath>..\..\..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/Styling/DragAndDrop/DragOverConditional/MainWindow.xaml
+++ b/Styling/DragAndDrop/DragOverConditional/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DragOverConditional"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         mc:Ignorable="d"
         Title="MainWindow" Height="350" Width="525">
     <Grid>

--- a/Styling/DragAndDrop/DragOverConditional/packages.config
+++ b/Styling/DragAndDrop/DragOverConditional/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MaterialDesignColors" version="1.1.3" targetFramework="net462" />
   <package id="MaterialDesignThemes" version="2.5.1" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.0.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Remove reference to the obsolete Microsoft.Expression.Interactions and System.Windows.Interactivity for Style/DragAndDrop.sln

1. Install the Microsoft.Xaml.Behaviors.Wpf NuGet package.
2.  XAML files – replace the xmlns namespaces http://schemas.microsoft.com/expression/2010/interactivity  with http://schemas.microsoft.com/xaml/behaviors
3. C# files – replace the usings in c# files Microsoft.Xaml.Interactivity  with Microsoft.Xaml.Behaviors