### PR TITLE
add a property "Title" to MainViewModel

### DIFF
--- a/TabControl/TabControl.MVVM/MainWindowViewModel.cs
+++ b/TabControl/TabControl.MVVM/MainWindowViewModel.cs
@@ -9,6 +9,9 @@ public partial class MainWindowViewModel
 {
     private int _counter = 1;
     public ObservableCollection<TabItemViewModel> Tabs { get; } = new();
+ 
+    [ObservableProperty]
+    private string? _title = "Main_Title";
 
 	public MainWindowViewModel()
 	{


### PR DESCRIPTION
Or it will cause a binding error in the following code of MainWindow, as the DataContext of this section is MainViewModel

https://github.com/Keboo/MaterialDesignInXaml.Examples/blob/a3d41ac3896d5a91b7e588ea72738eb28378c6c8/TabControl/TabControl.MVVM/MainWindow.xaml#L61

```xml
<TabControl Grid.Row="3">
    <TabItem Header="Item 1">
        <local:RefCountingControl Background="Red" />
    </TabItem>
    <TabItem Header="Item 2">
        <local:RefCountingControl Background="BlueViolet" />
    </TabItem>
    <TabItem Header="Item 3">
        <local:RefCountingControl Background="Fuchsia" />
    </TabItem>
</TabControl>
```